### PR TITLE
Feature/batch updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem was largely inspired by [hubspot-api-ruby](https://github.com/captaincontrat/hubspot-api-ruby) which, in turn, was inspired by the [hubspot-ruby](https://github.com/HubspotCommunity/hubspot-ruby) community gem. I wanted to use version 3 of the api and simplify some parts of the interface
 
-The Ruby HubSpot API gem is a starting point for building an ORM-like interface to HubSpot's API. 
+The Ruby HubSpot API gem is a starting point for building an ORM-like interface to HubSpot's API.
 
 ## Installation
 
@@ -44,11 +44,9 @@ _(N.B when referring to the resources in the api we will refer to them as Object
 
 This gem allows you to interact with HubSpot objects such as contacts and companies. You can perform operations on individual instances (e.g., creating or updating records) as well as on collections (e.g., listing or searching).
 
-### Instance Methods
+### Creating and Saving an Object
 
-#### Creating and Saving an Object
-
-You can instantiate a new resource (such as a contact) by passing a hash of properties when creating the object. After setting the properties, calling `save` will persist the object to the HubSpot API.
+Create and instance of the resource passing a hash of properties. Calling `save` on the instance will persist the object to the HubSpot API, as well as set the id property (which you can then store in your own database for example)
 
 Example:
 
@@ -62,7 +60,7 @@ new_contact.save
 puts "New contact ID: #{new_contact.id}"
 ```
 
-#### Retreiving an Object
+### Retreiving an Object
 
 If you know the id of the object you can fetch it from the api using the find method
 
@@ -83,44 +81,75 @@ contact = Hubspot::Contact.find_by('member_id', 123)
 puts "Contact: #{contact.firstname} #{contact.lastname}"
 ```
 
-#### Updating an Existing Object
+### Updating an Existing Object
 
-To update an existing object, you can either modify the object and call `save`, or use the `update` method specifying the properties you want to update
+To update an existing object, you can either modify the object and call `save`, or use the `update` method specifying the properties you want to update. You can test whether or not the object will need to upload changes to the api by using the changes? method
 
 Example using `save`:
 
 ```ruby
 contact = Hubspot::Contact.find(1)
+contact.changes? # false
+
 contact.lastname = 'DoeUpdated'
+contact.changes? # true
+
+# save the updates to Hubspot
 contact.save # true
+contact.changes? # false
 ```
 
 Example using `update`:
 
 ```ruby
 contact = Hubspot::Contact.find(1)
+# save the updates to Hubspot
 contact.update(lastname: 'DoeUpdated') # true
 ```
 
-### Class Methods
+If you are able to construct an Object with data stored locally you can save the inital `find` api call, but you will need to construct the persisted object specifying the id and a properties hash (as if it came from the api!)
 
-#### Listing Objects
+Example:
 
-You can list all objects (such as contacts) using the `list` method, which returns a `PagedCollection`. This collection handles paginated results and responds to methods like `each_page`, `each`, and `all`. You can also pass the `page_size` parameter to control the number of records returned per page.
+```ruby
+local_contact = Contact.find(contact_id)
+
+hubspot_properties = {
+  firstname: local_contact.first_name,
+  lastname: local_contact.last_name,
+  email: local_contact.email,
+  # ... more properties...
+}
+
+hubspot_contact = Hubspot::Contact.new(id: contact.hs_object_id, properties: hubspot_properties )
+hubspot_contact.changes? # false
+
+# update a custom field "last_contacted"
+# (in the hubspot_contact instance this will be stored in the changes property)
+hubspot_contact.last_contacted = Time.now.utc.iso8601
+hubspot_contact.changes? # true
+
+# persist the change to hubspot
+hubspot_contact.save #true
+```
+
+### Listing Objects
+
+You can list all objects (such as contacts) using the `list` method, which returns a `PagedCollection`. This collection handles paginated results and is Enumerable, so responds to methods like `each_page`, `each`, and `all`. You can also pass the `page_size` parameter to control the number of records returned per page.
 
 Example:
 
 ```ruby
 contacts = Hubspot::Contact.list(page_size: 10)
 
-# Using each_page to iterate over pages
+# Using each_page to iterate over pages, there will be up to 10 contacts per page
 contacts.each_page do |page|
   page.each do |contact|
     puts "Contact: #{contact.firstname} #{contact.lastname}"
   end
 end
 
-# Or iterate over all contacts without worrying about pagination
+# Or iterate over all contacts and the pagination will be handled transparently (page_size still applies)
 contacts.each do |contact|
   puts "Contact: #{contact.firstname} #{contact.lastname}"
 end
@@ -129,23 +158,42 @@ end
 all_contacts = contacts.all
 ```
 
-#### Retrieving the first n items
+#### Retrieving the first n items:
 
-You can use the `first` method to retrieve the first item or a specified number of items:
+As mentioned the list method returns a PagedCollection. You can call `first` on the result to retrieve the first item or a specified number of items:
 
 ```ruby
-contacts = Hubspot::Contact.list(page_size: 10)
+contacts_collection = Hubspot::Contact.list
 
 # Retrieve the first contact
-first_contact = contacts.first
+first_contact = contacts_collection.first
 
 # Retrieve the first 5 contacts
-first_five_contacts = contacts.first(5)
+first_five_contacts = contacts_collection.first(5)
 ```
 
 This will automatically set the limits and handle paging for the most efficient API calls while honouring the maximum page count for hubspot resources
 
-#### Searching
+#### Specifying properties
+
+By default Hubspot will only send back the [default hubspot properties](https://knowledge.hubspot.com/properties/hubspots-default-contact-properties)
+
+You can pass an array of properties to be return as follows:
+
+Example:
+
+```ruby
+# Search for contacts with email containing "hubspot.com" and only return specific properties
+contacts = Hubspot::Contact.list(
+  properties: ['firstname', 'lastname', 'email', 'mobile', 'custom_property_1']
+)
+
+contacts.each do |contact|
+  puts "Name: #{contact.firstname} #{contact.lastname}, Email: #{contact.email}, Mobile: #{contact.mobile} CustomerRef: #{contact.custom_property_1}"
+end
+```
+
+### Searching
 
 You can search for objects by passing query parameters to the `search` method. HubSpot supports several operators such as `eq`, `gte`, `lt`, and `IN` for filtering.
 
@@ -155,15 +203,21 @@ Example:
 # Search for contacts with email containing "hubspot.com"
 contacts = Hubspot::Contact.search(query: { email_contains: 'hubspot.com' })
 
+puts "Searching for Hubspot staff in the contacts CRM"
+puts ""
+
 contacts.each do |contact|
-  puts "Found: #{contact.email}"
+  puts "  Found: #{contact.firstname} #{contact.lastname} (#{contact.email})"
 end
 
 # Search for companies with number of employees greater than or equal to 100
 companies = Hubspot::Company.search(query: { number_of_employees_gte: 100 })
 
+puts "Searching for medium to large companies"
+puts ""
+
 companies.each do |company|
-  puts "Found: #{company.name}, Employees: #{company.number_of_employees}"
+  puts "  Found: #{company.name} (#{company.number_of_employees} employees)"
 end
 
 # Search for contacts with email in a specific list (IN operator)
@@ -175,15 +229,18 @@ end
 ```
 
 ### Available Search Operators:
-- **eq**: Equal to.
+- **contains**: contains <string>
 - **neq**: Not equal to.
+- **gt**: Greater than.
 - **gte**: Greater than or equal to.
+- **lt**: Less than.
 - **lte**: Less than or equal to.
 - **IN**: Matches any of the values in an array.
 
 #### Specifying Properties in Search
 
-When performing a search, you can also specify which properties to return. If you specify any properties, you will only get those properties back, and the default HubSpot properties will not be included automatically.
+When performing a search, you can also specify which properties to return.
+*NB* If you specify any properties, you will only get those properties back, and the default HubSpot properties will not be included automatically.
 
 Example:
 
@@ -195,9 +252,158 @@ contacts = Hubspot::Contact.search(
 )
 
 contacts.each do |contact|
-  puts "Name: #{contact.firstname} #{contact.lastname}, Email: #{contact.email}, Mobile: #{contact.mobile}"
+  puts "Name: #{contact.firstname} #{contact.lastname}, Email: #{contact.email}, Mobile: #{contact.mobile} CustomerRef: #{contact.custom_property_1}"
 end
 ```
+
+## Working with batches
+
+### Hubspot::Batch
+
+The `Hubspot::Batch` class allows you to perform batch operations on HubSpot resources, such as contacts or companies. This includes batch `create`, `read`, `update`, `upsert`, and `archive` operations. Below are examples of how to use these methods.
+
+#### Batch Create
+
+To create new resources in bulk, you can use the `create` method.
+
+In this example, `batch.create` triggers the creation of new contacts. After creation, the batch response will include the new IDs assigned to each object by HubSpot which will be assigned to the resources in the batch
+
+```ruby
+contacts = [
+  Hubspot::Contact.new(email: 'new.john@example.com', firstname: 'John', lastname: 'Doe'),
+  Hubspot::Contact.new(email: 'new.jane@example.com', firstname: 'Jane', lastname: 'Doe')
+]
+
+batch = Hubspot::Batch.new(contacts)
+batch.create
+
+batch.resources.each do |contact|
+  hubspot_id = contact.id
+  # store hubspot_id against a contact....
+end
+```
+
+
+#### Batch Read
+
+To read a batch of Objects by their internal hubspot id or by another uniq property you can use the `read` method. You will need to pass the class of the resource, an array of ids and optionally an id_property.
+
+ For simplicity you can also use the `batch_read` method of the corresponding class (e.g. Hubspot::Contacts, Hubspot::Company etc) passing an array of ids and optionally an id_property (defaults to 'id'). This method will return a Hubspot::Batch and the results will be in "resources"
+
+Example using `read` along with the Hubspot id of several companies...
+
+```ruby
+# Grab an array of hubspot company ids to read from the api...
+company_ids = my_companies.collect(&:hubspot_id).compact
+
+# this will grab all the results from the api handling paging automagically
+batch = Hubspot::Batch.read(Hubspot::Company, company_ids)
+companies = batch.resources
+
+# Or using the domain field
+# Grab an array of company domains
+company_domains = my_companies.collect(&:domain_name).compact
+
+# calls /crm/v3/objects/companies/batch/read
+batch = Hubspot::Batch.read(Hubspot::Company, company_domains, id_property: 'domain')
+companies = batch.resources
+```
+
+Example of reading contacts by email and the helper method `batch_read`
+By using this method you can page through the results as needed or collect them 
+
+```ruby
+email_addresses = my_selected_contacts.collect(&:email).compact
+
+batch = Hubspot::Contact.batch_read(email_addresses, id_property: 'email')
+
+batch.each_page do |contacts|
+  contacts.each do |contact|
+    # persist some data locally
+    update_local_contact_from_hubspot(contact)
+  end
+  # stop the api calls if a condition is met
+  # break if <condition>
+end
+```
+
+Finally there is another helper method on re
+
+#### Batch Update
+
+For updating existing resources in bulk, you can use the `update` method. If you want to locally create an object without calling the API you specify the id and pass any properties in the 'properties' hash (this is how the objects are returned from Hubspot)
+
+```ruby
+contacts = [
+  Hubspot::Contact.new(id: 1, properties: { firstname: 'John', lastname: 'Doe' }),
+  Hubspot::Contact.new(id: 2, properties: { firstname: 'Jane', lastname: 'Doe' })
+]
+
+# make a changes to each contact
+contacts.each { |contact| contact.last_contacted = Time.now.utc.iso8601 }
+
+batch = Hubspot::Batch.new(contacts)
+batch.update
+```
+
+Example using a batch
+```ruby
+contact_ids = my_contacts.collect(&:hubspot_id).compact
+batch = Hubspot::contacts.batch_read(contact_ids)
+
+batch.resources.each do |hubspot_contact|
+  my_contact = my_contacts.find { |c| c.hubspot_id == hubspot_contact.id }
+  # some logic or method to set any new/changed properties on hubspot_contact
+  update_hubspot_contact_from_local(hubspot_contact, my_contact)
+end
+
+# now we have a batch with changed resources we can update the batch
+batch.update # true
+```
+
+#### Batch Upsert
+
+The `upsert` method allows you to insert new records or update existing ones. You’ll need to specify an `id_property` (like `email`) to uniquely identify records
+
+```ruby
+contacts = [
+  Hubspot::Contact.new(email: 'new.john@example.com', firstname: 'John', lastname: 'Doe'),
+  Hubspot::Contact.new(email: 'new.jane@example.com', firstname: 'Jane', lastname: 'Doe')
+]
+
+batch = Hubspot::Batch.new(contacts, id_property: 'email')
+batch.upsert
+```
+
+In this example, if a contact with the given email already exists in HubSpot, it will be updated. If it doesn't, a new contact will be created.
+
+#### Batch Archive
+
+To archive objects in bulk, you can use the `archive` method. This removes the objects from HubSpot.
+
+```ruby
+contacts = Hubspot::Contact.search(query: { email_contains: 'hubspot.com' }).all
+
+batch = Hubspot::Batch.new(contacts)
+batch.archive
+```
+
+The `archive` method sends a batch request to HubSpot to archive the objects. If any of the objects fail to be archived, you can check for partial success using the `partial_success?` method.
+
+#### Error Handling and Success Checks
+
+You can check whether the batch operation was entirely successful, partially successful, or if any failures occurred:
+
+```ruby
+if batch.all_successful?
+  puts "All resources were successfully processed."
+elsif batch.partial_success?
+  puts "Some resources were successfully processed, but others failed."
+else
+  puts "The batch operation failed."
+end
+```
+
 
 ## Contributing
 

--- a/lib/hubspot.rb
+++ b/lib/hubspot.rb
@@ -19,6 +19,7 @@ module Hubspot
     def configure
       yield(config) if block_given?
       set_client_headers if config.access_token
+      set_request_timeouts
     end
 
     def configured?
@@ -30,6 +31,19 @@ module Hubspot
     # Set Authorization header on Hubspot::ApiClient when access_token is configured
     def set_client_headers
       Hubspot::ApiClient.headers 'Authorization' => "Bearer #{config.access_token}"
+    end
+
+    def set_request_timeouts
+      config.timeout && Hubspot::ApiClient.default_timeout(config.timeout)
+      timeouts = %i[open_timeout read_timeout]
+      timeouts << :write_timeout if RUBY_VERSION >= '2.6'
+
+      timeouts.each do |t|
+        timeout = config.send(t)
+        next unless timeout
+
+        Hubspot::ApiClient.send(t, timeout)
+      end
     end
   end
 end

--- a/lib/hubspot/api_client.rb
+++ b/lib/hubspot/api_client.rb
@@ -32,7 +32,7 @@ module Hubspot
         ensure_configuration!
         start_time = Time.now
         response = super(url, options)
-        log_request(:post, url, response, start_time)
+        log_request(:post, url, response, start_time, options)
         response
       end
 
@@ -40,7 +40,7 @@ module Hubspot
         ensure_configuration!
         start_time = Time.now
         response = super(url, options)
-        log_request(:patch, url, response, start_time)
+        log_request(:patch, url, response, start_time, options)
         response
       end
 
@@ -52,10 +52,13 @@ module Hubspot
         response
       end
 
-      def log_request(http_method, url, response, start_time)
+      def log_request(http_method, url, response, start_time, extra = nil)
         d = Time.now - start_time
         Hubspot.logger.info("#{http_method.to_s.upcase} #{url} took #{d.round(2)}s with status #{response.code}")
-        Hubspot.logger.debug("Response body: #{response.body}") if Hubspot.logger.debug?
+        return unless Hubspot.logger.debug?
+
+        Hubspot.logger.debug("Request body: #{extra}") if extra
+        Hubspot.logger.debug("Response body: #{response.body}")
       end
 
       def handle_response(response)

--- a/lib/hubspot/batch.rb
+++ b/lib/hubspot/batch.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module Hubspot
+  # exactly the same as a parsed_response but with the status code preserved
+  class BatchResponse < SimpleDelegator
+    attr_reader :status_code
+
+    def initialize(status_code, parsed_response)
+      @status_code = status_code
+      super(parsed_response) # Delegate to the parsed response object
+    end
+
+    # Check if all responses were successful (status 200)
+    def all_successful?
+      @status_code == 200
+    end
+
+    # Check if some responses succeeded and some failed (status 207)
+    def partial_success?
+      @status_code == 207
+    end
+  end
+
+  # Class to handle batch updates of resources
+  class Batch < ApiClient
+    attr_accessor :id_property, :resources, :responses
+
+    CONTACT_LIMIT = 10
+    DEFAULT_LIMIT = 100
+
+    # rubocop:disable Lint/MissingSuper
+    def initialize(resources = [], id_property: 'id')
+      @resources = []
+      @id_property = id_property # Set id_property for the batch (default: 'id')
+      @responses = []            # Store multiple BatchResponse objects here
+      resources.each { |resource| add_resource(resource) }
+    end
+    # rubocop:enable Lint/MissingSuper
+
+    # Save the batch and return true/false based on whether it was successful
+    def save(endpoint: 'update')
+      resource_type = check_single_resource_type
+      inputs = gather_inputs
+
+      return false if inputs.empty? # Guard clause
+
+      # Perform the batch updates in chunks based on the resource type's limit
+      batch_limit = batch_size_limit(resource_type)
+      inputs.each_slice(batch_limit) do |batch_inputs|
+        response = batch_request(resource_type, batch_inputs, endpoint)
+        @responses << response
+      end
+
+      # Check if any responses failed
+      !any_failed?
+    end
+
+    # Upsert method that calls save with upsert endpoint
+    def upsert
+      validate_upsert_conditions
+      save(endpoint: 'upsert')
+    end
+
+    # Check if all responses were successful
+    def all_successful?
+      @responses.all?(&:all_successful?)
+    end
+
+    # Check if some responses were successful and others failed
+    def partial_success?
+      @responses.any?(&:partial_success?) && @responses.none?(&:all_successful?)
+    end
+
+    # Check if any responses failed
+    def any_failed?
+      @responses.any? { |response| !response.all_successful? && !response.partial_success? }
+    end
+
+    private
+
+    def add_resource(resource)
+      if @resources.any? && @resources.first.resource_name != resource.resource_name
+        raise ArgumentError, 'All resources in a batch must be of the same type'
+      end
+
+      @resources << resource
+    end
+
+    def check_single_resource_type
+      raise 'Batch is empty' if @resources.empty?
+
+      @resources.first.resource_name
+    end
+
+    # Gather all the changes, ensuring each resource has an id and changes
+    def gather_inputs
+      @resources.map do |resource|
+        next if resource.changes.empty?
+
+        {
+          id: resource.public_send(@id_property),   # Dynamically get the ID based on the batch's id_property
+          idProperty: determine_id_property,        # Use the helper method to decide whether to include idProperty
+          properties: resource.changes              # Gather the changes for the resource
+        }.compact   # Removes nil keys
+      end.compact   # Removes nil entries
+    end
+
+    # Only include idProperty if it's not "id"
+    def determine_id_property
+      @id_property == 'id' ? nil : @id_property
+    end
+
+    # Perform batch request based on the provided endpoint (upsert or update)
+    def batch_request(type, inputs, endpoint)
+      response = post("/crm/v3/objects/#{type}/batch/#{endpoint}", body: { inputs: inputs })
+      BatchResponse.new(response.code, handle_response(response))
+    end
+
+    # Validation for upsert conditions
+    def validate_upsert_conditions
+      raise ArgumentError, "id_property cannot be 'id' for upsert" if @id_property == 'id'
+
+      if @resources.any? { |resource| resource.public_send(id_property).blank? }
+        raise ArgumentError, "All resources must have a non-blank value for #{@id_property} to perform upsert"
+      end
+    end
+
+    # Return the appropriate batch size limit for the resource type
+    def batch_size_limit(resource_type)
+      resource_type == 'contacts' ? CONTACT_LIMIT : DEFAULT_LIMIT
+    end
+  end
+end

--- a/lib/hubspot/batch.rb
+++ b/lib/hubspot/batch.rb
@@ -24,6 +24,7 @@ module Hubspot
   end
 
   # Class to handle batch updates of resources
+  # rubocop:disable Metrics/ClassLength
   class Batch < ApiClient
     attr_accessor :id_property, :resources, :responses
 
@@ -39,28 +40,25 @@ module Hubspot
     end
     # rubocop:enable Lint/MissingSuper
 
-    # Save the batch and return true/false based on whether it was successful
-    def save(endpoint: 'update')
-      resource_type = check_single_resource_type
-      inputs = gather_inputs
-
-      return false if inputs.empty? # Guard clause
-
-      # Perform the batch updates in chunks based on the resource type's limit
-      batch_limit = batch_size_limit(resource_type)
-      inputs.each_slice(batch_limit) do |batch_inputs|
-        response = batch_request(resource_type, batch_inputs, endpoint)
-        @responses << response
-      end
-
-      # Check if any responses failed
-      !any_failed?
+    # batch create from the resources
+    def create
+      save(action: 'create')
     end
 
-    # Upsert method that calls save with upsert endpoint
+    def update
+      # validate_update_conditions
+      save(action: 'update')
+    end
+
+    # Upsert method that calls save with upsert action
     def upsert
       validate_upsert_conditions
-      save(endpoint: 'upsert')
+      save(action: 'upsert')
+    end
+
+    # Archive method
+    def archive
+      save(action: 'archive')
     end
 
     # Check if all responses were successful
@@ -78,8 +76,6 @@ module Hubspot
       @responses.any? { |response| !response.all_successful? && !response.partial_success? }
     end
 
-    private
-
     def add_resource(resource)
       if @resources.any? && @resources.first.resource_name != resource.resource_name
         raise ArgumentError, 'All resources in a batch must be of the same type'
@@ -87,6 +83,30 @@ module Hubspot
 
       @resources << resource
     end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def save(action: 'update')
+      @action = action
+      resource_type = check_single_resource_type
+      inputs = gather_inputs
+
+      return false if inputs.empty? # Guard clause
+
+      # Perform the batch updates in chunks based on the resource type's limit
+      batch_limit = batch_size_limit(resource_type)
+      inputs.each_slice(batch_limit) do |batch_inputs|
+        response = batch_request(resource_type, batch_inputs, action)
+        @responses << response
+      end
+
+      process_responses unless @action == 'archive'
+
+      # Check if any responses failed
+      !any_failed?
+    end
+    # rubocop:enable Metrics/MethodLength
 
     def check_single_resource_type
       raise 'Batch is empty' if @resources.empty?
@@ -96,6 +116,8 @@ module Hubspot
 
     # Gather all the changes, ensuring each resource has an id and changes
     def gather_inputs
+      return gather_archive_inputs if @action == 'archive'
+
       @resources.map do |resource|
         next if resource.changes.empty?
 
@@ -107,14 +129,24 @@ module Hubspot
       end.compact   # Removes nil entries
     end
 
+    # Gather inputs for the archive operation
+    def gather_archive_inputs
+      @resources.map do |resource|
+        {
+          id: resource.public_send(@id_property),   # Use the ID or the custom property
+          idProperty: determine_id_property         # Include idProperty if it's not "id"
+        }.compact
+      end.compact
+    end
+
     # Only include idProperty if it's not "id"
     def determine_id_property
       @id_property == 'id' ? nil : @id_property
     end
 
-    # Perform batch request based on the provided endpoint (upsert or update)
-    def batch_request(type, inputs, endpoint)
-      response = post("/crm/v3/objects/#{type}/batch/#{endpoint}", body: { inputs: inputs })
+    # Perform batch request based on the provided action (upsert, update, create, or archive)
+    def batch_request(type, inputs, action)
+      response = self.class.post("/crm/v3/objects/#{type}/batch/#{action}", body: { inputs: inputs }.to_json)
       BatchResponse.new(response.code, handle_response(response))
     end
 
@@ -122,14 +154,87 @@ module Hubspot
     def validate_upsert_conditions
       raise ArgumentError, "id_property cannot be 'id' for upsert" if @id_property == 'id'
 
-      if @resources.any? { |resource| resource.public_send(id_property).blank? }
-        raise ArgumentError, "All resources must have a non-blank value for #{@id_property} to perform upsert"
-      end
+      # check if there are any resources without a value from the id_property
+      return unless @resources.any? { |resource| resource.public_send(id_property).blank? }
+
+      raise ArgumentError, "All resources must have a non-blank value for #{@id_property} to perform upsert"
     end
 
     # Return the appropriate batch size limit for the resource type
     def batch_size_limit(resource_type)
       resource_type == 'contacts' ? CONTACT_LIMIT : DEFAULT_LIMIT
     end
+
+    # Process responses from the batch API call
+    def process_responses
+      @responses.each do |response|
+        next unless response['results']
+
+        process_results(response['results'])
+      end
+    end
+
+    # Process each result and update the resource accordingly
+    def process_results(results)
+      results.each do |result|
+        resource = find_resource_from_result(result)
+        next unless resource
+
+        # Set the ID on the resource directly
+        resource.id = result['id'].to_i if result['id']
+
+        # Update the resource properties
+        update_resource_properties(resource, result['properties'])
+
+        # Update metadata like updatedAt
+        update_metadata(resource, result['updatedAt'])
+      end
+    end
+
+    def find_resource_from_result(result)
+      case @action
+      when 'update', 'upsert'
+        find_resource_from_id(result['id'].to_i)
+
+      #
+      # when specifying idProperty in the upsert request
+      # the Hubspot API returns the id value (aka the hs_object_id)
+      # instead of the value of the <idProperty> field, so the value of the field
+      # is only stored in results['properties'][@id_property] if it changed!
+      # so this condition is redundant but left here in case Hubspot updates the response
+      #
+      # when 'upsert'
+      #   resource_id = result.dig('properties', @id_property) || result['id']
+      #   find_resource_from_id_property(resource_id)
+      #
+      when 'create'
+        # For create, check if the resource's changes are entirely contained in the result's properties
+        @resources.reject(&:persisted?).find do |resource|
+          resource.changes.any? && resource.changes.all? { |key, value| result['properties'][key.to_s] == value }
+        end
+      end
+    end
+
+    def find_resource_from_id(resource_id)
+      @resources.find { |r| r.id == resource_id }
+    end
+
+    # def find_resource_from_id_property(resource_id)
+    #   @resources.find { |r| r.public_send(@id_property) == resource_id }
+    # end
+
+    def update_resource_properties(resource, properties)
+      properties.each do |key, value|
+        if resource.changes[key]
+          resource.properties[key] = value
+          resource.changes.delete(key)
+        end
+      end
+    end
+
+    def update_metadata(resource, updated_at)
+      resource.metadata['updatedAt'] = updated_at if updated_at
+    end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/hubspot/batch.rb
+++ b/lib/hubspot/batch.rb
@@ -235,6 +235,18 @@ module Hubspot
     def update_metadata(resource, updated_at)
       resource.metadata['updatedAt'] = updated_at if updated_at
     end
+
+    class << self
+      def read(object_class, object_ids = [], id_property: 'id')
+        raise ArgumentError, 'Must be a valid Hubspot resource class' unless object_class < Hubspot::Resource
+
+        # fetch all the matching resources with paging handled
+        resources = object_class.batch_read(object_ids, id_property: id_property).all
+
+        # return instance of Hubspot::Batch with the resources set
+        new(resources, id_property: id_property)
+      end
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -3,7 +3,8 @@
 module Hubspot
   # To hold Hubspot configuration
   class Config
-    attr_accessor :access_token, :portal_id, :client_secret, :logger, :log_level
+    attr_accessor :access_token, :portal_id, :client_secret, :logger, :log_level,
+                  :timeout, :open_timeout, :read_timeout, :write_timeout
 
     def initialize
       @access_token = nil

--- a/lib/hubspot/paged_batch.rb
+++ b/lib/hubspot/paged_batch.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative './api_client'
+require_relative './exceptions'
+
+module Hubspot
+  # Enumerable class for handling paged data from the API
+  class PagedBatch < ApiClient
+    include Enumerable
+
+    MAX_LIMIT = 100 # HubSpot max items per page
+
+    # rubocop:disable Lint/MissingSuper
+    def initialize(url:, params: {}, resource_class: nil, object_ids: [])
+      @url = url
+      @params = params
+      @resource_class = resource_class
+      @object_ids = object_ids
+    end
+    # rubocop:enable Lint/MissingSuper
+
+    def each_page
+      @object_ids.each_slice(MAX_LIMIT) do |ids|
+        response = fetch_page(ids)
+        results = response['results'] || []
+        mapped_results = @resource_class ? results.map { |result| @resource_class.new(result) } : results
+        yield mapped_results unless mapped_results.empty?
+      end
+    end
+
+    def all
+      results = []
+      each_page do |page|
+        results.concat(page)
+      end
+      results
+    end
+
+    def each(&block)
+      each_page do |page|
+        page.each(&block)
+      end
+    end
+
+    private
+
+    def fetch_page(object_ids)
+      params_with_ids = @params.dup
+      params_with_ids[:inputs] = object_ids.map { |id| { id: id } }
+
+      response = self.class.post(@url, body: params_with_ids.to_json)
+
+      handle_response(response)
+    end
+  end
+end

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -111,8 +111,6 @@ module Hubspot
 
       # rubocop:enable Metrics/MethodLength
 
-      private
-
       # Define the resource name based on the class
       def resource_name
         name = self.name.split('::').last.downcase
@@ -122,6 +120,8 @@ module Hubspot
           "#{name}s" # Contact -> contacts, Deal -> deals
         end
       end
+
+      private
 
       # Instantiate a single resource object from the response
       def instantiate_from_response(response)
@@ -240,19 +240,15 @@ module Hubspot
       end
 
       # Fallback if the method or attribute is not found
-      # :nocov:
       super
-      # :nocov:
     end
     # rubocop:enable Metrics/MethodLength
 
     # Ensure respond_to_missing? is properly overridden
-    # :nocov:
     def respond_to_missing?(method_name, include_private = false)
       property_name = method_name.to_s.chomp('=')
       @properties.key?(property_name) || @changes.key?(property_name) || super
     end
-    # :nocov:
 
     private
 

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -161,10 +161,10 @@ module Hubspot
 
     # rubocop:disable Ling/MissingSuper
     def initialize(data = {})
+      data.transform_keys!(&:to_s)
       @id = extract_id(data)
       @properties = {}
       @metadata = {}
-
       if @id
         initialize_from_api(data)
       else

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -173,6 +173,10 @@ module Hubspot
     end
     # rubocop:enable Ling/MissingSuper
 
+    def changes?
+      !@changes.empty?
+    end
+
     # Instance methods for update (or save)
     def save
       if persisted?

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative './api_client'
+require_relative './paged_collection'
+require_relative './paged_batch'
 
 module Hubspot
   # rubocop:disable Metrics/ClassLength
@@ -51,6 +53,21 @@ module Hubspot
           params: params,
           resource_class: self
         )
+      end
+
+      def batch_read(object_ids = [], id_property: 'id')
+        params = id_property == 'id' ? {} : { idProperty: id_property }
+
+        PagedBatch.new(
+          url: "/crm/v3/objects/#{resource_name}/batch/read",
+          params: params,
+          object_ids: object_ids,
+          resource_class: self
+        )
+      end
+
+      def batch_read_all(object_ids = [], id_property: 'id')
+        Hubspot::Batch.read(self, object_ids, id_property: id_property)
       end
 
       # Get the complete list of fields (properties) for the object

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -211,6 +211,10 @@ module Hubspot
     end
     alias archive delete
 
+    def resource_name
+      self.class.resource_name
+    end
+
     # rubocop:disable Metrics/MethodLength
     # Handle dynamic getter and setter methods with method_missing
     def method_missing(method, *args)

--- a/lib/ruby_hubspot_api.rb
+++ b/lib/ruby_hubspot_api.rb
@@ -20,4 +20,7 @@ require_relative 'hubspot/company'
 require_relative 'hubspot/user'
 
 # Load other components
+require_relative 'hubspot/batch'
 require_relative 'hubspot/paged_collection'
+
+require_relative 'support/patches'

--- a/lib/support/patches.rb
+++ b/lib/support/patches.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# simplest monkey patch, honest ;)
+class Object
+  # Only define blank? if it's not already defined
+  unless method_defined?(:blank?)
+    def blank?
+      respond_to?(:empty?) ? empty? : !self
+    end
+  end
+end

--- a/spec/hubspot/api_client_spec.rb
+++ b/spec/hubspot/api_client_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Hubspot::ApiClient do
+  include_examples 'hubspot configuration'
+  let(:logger) { instance_double(Logger) }
+
+  before do
+    # Mock the logger to capture the output
+    allow(Hubspot).to receive(:logger).and_return(logger)
+
+    # Mock the logger methods to allow checking log messages
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:debug)
+
+    # Stub the actual HTTP POST request using WebMock's `stub_request`
+    stub_request(:post, %r{/crm/v3/objects/contacts})
+      .to_return(status: 200, body: '{"success":true}', headers: { 'Content-Type' => 'application/json' })
+  end
+
+  context 'when the log level is set to debug' do
+    before do
+      # Ensure that logger.debug? returns true
+      allow(logger).to receive(:debug?).and_return(true)
+    end
+
+    it 'logs request and response body during a contact POST request' do
+      # Make a POST request using the Contact class
+      Hubspot::Contact.create(name: 'John Doe')
+
+      # Check that logger.info was called
+      expect(logger).to have_received(:info).with(/POST .* took \d+\.\d+s with status 200/)
+
+      # Check that logger.debug was called for both request and response bodies
+      expect(logger).to have_received(:debug).with(/Request body:/)
+      expect(logger).to have_received(:debug).with(/Response body:/)
+    end
+  end
+
+  context 'when the log level is not set to debug' do
+    before do
+      # Ensure that logger.debug? returns false
+      allow(logger).to receive(:debug?).and_return(false)
+    end
+
+    it 'does not log request and response body during a contact POST request' do
+      # Make a POST request using the Contact class
+      Hubspot::Contact.create(name: 'John Doe')
+
+      # Check that logger.info was called
+      expect(logger).to have_received(:info).with(/POST .* took \d+\.\d+s with status 200/)
+
+      # Ensure that logger.debug was NOT called
+      expect(logger).not_to have_received(:debug)
+    end
+  end
+end

--- a/spec/hubspot/batch_spec.rb
+++ b/spec/hubspot/batch_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+RSpec.describe Hubspot::Batch do
+  let(:resource1) { instance_double('Resource', changes: { name: 'John' }, resource_name: 'contacts') }
+  let(:resource2) { instance_double('Resource', changes: { name: 'Jane' }, resource_name: 'contacts') }
+  let(:invalid_resource) { instance_double('InvalidResource', resource_name: 'invalid_resource') }
+  let(:contact) do
+    instance_double('Contact', changes: { name: 'John' }, resource_name: 'contacts', email: 'john@example.com')
+  end
+
+  let(:company) do
+    instance_double('Company', changes: { name: 'Acme Corp' }, resource_name: 'companies', internal_id: 123)
+  end
+
+  context 'with valid resources' do
+    let(:batch) { Hubspot::Batch.new([resource1, resource2]) }
+
+    it 'initializes successfully' do
+      expect(batch).to be_a(Hubspot::Batch)
+    end
+  end
+
+  context 'with mixed resource types' do
+    it 'raises a Hubspot::ArgumentError' do
+      expect { Hubspot::Batch.new([resource1, invalid_resource]) }.to raise_error(Hubspot::ArgumentError, /same type/)
+    end
+  end
+
+  describe '#save' do
+    before do
+      # Mock HTTParty::Response to behave like a real response object
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: {}, success?: true)
+
+      # Mock the post method in ApiClient to return the HTTParty::Response object
+      allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(response)
+    end
+
+    context 'when resources are empty' do
+      let(:batch) { Hubspot::Batch.new([]) }
+
+      it 'raises an error' do
+        expect { batch.save }.to raise_error(RuntimeError, 'Batch is empty')
+      end
+    end
+
+    it 'makes a call to the correct update URL' do
+      contacts = Array.new(5) { contact } # 5 contacts
+      batch = Hubspot::Batch.new(contacts, id_property: 'email')
+
+      batch.save # This should trigger the update endpoint
+
+      # Expect the post method to have been called with the correct update URL
+      expect(batch).to have_received(:post).with('/crm/v3/objects/contacts/batch/update', any_args)
+    end
+
+    context 'when batch size exceeds contact limit (10)' do
+      it 'honours the batch limits and makes multiple calls' do
+        contacts = Array.new(15) { contact } # 15 contacts
+        batch = Hubspot::Batch.new(contacts, id_property: 'email')
+
+        # Call save and expect post to be called twice (15 / 10 = 2 API calls)
+        batch.save
+        expect(batch.responses.size).to eq(2)
+      end
+    end
+
+    context 'when batch size exceeds default limit (100)' do
+      it 'makes more than one API call for other objects' do
+        companies = Array.new(150) { company } # 150 companies
+
+        batch = Hubspot::Batch.new(companies, id_property: 'internal_id')
+
+        # Call save and expect post to be called twice (150 / 100 = 2 API calls)
+        batch.save
+        expect(batch.responses.size).to eq(2)
+      end
+    end
+
+    context 'when some resources fail' do
+      before do
+        partial_success_response = instance_double(HTTParty::Response, code: 207, parsed_response: {}, success?: true)
+        allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(partial_success_response)
+      end
+
+      it 'returns a partial success' do
+        companies = Array.new(5) { company }
+        batch = Hubspot::Batch.new(companies, id_property: 'internal_id')
+
+        expect(batch.save).to be true
+        expect(batch.partial_success?).to be true
+        expect(batch.all_successful?).to be false
+      end
+    end
+  end
+
+  describe '#upsert' do
+    let(:companies) { Array.new(5) { company } } # 5 companies
+
+    before do
+      # Mock HTTParty::Response to behave like a response object
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: {}, success?: true)
+
+      # Mock the post method in ApiClient to return the HTTParty::Response object
+      allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(response)
+    end
+
+    it 'makes a call to the correct upsert URL' do
+      batch = Hubspot::Batch.new(companies, id_property: 'internal_id')
+
+      batch.upsert # This should trigger the upsert endpoint
+
+      # Expect the post method to have been called with the correct upsert URL
+      expect(batch).to have_received(:post).with('/crm/v3/objects/companies/batch/upsert', any_args)
+    end
+
+    context "when some resources don't have a value for the id property" do
+      let(:incomplete_company) do
+        instance_double('Company', changes: { name: 'Acme Corp' }, resource_name: 'companies', internal_id: nil)
+      end
+      let(:companies_including_incomplete) { (companies << incomplete_company) }
+
+      it 'will raise an error' do
+        batch = Hubspot::Batch.new(companies_including_incomplete, id_property: 'internal_id')
+        expect{ batch.upsert }.to raise_error(Hubspot::ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/hubspot/batch_spec.rb
+++ b/spec/hubspot/batch_spec.rb
@@ -1,45 +1,127 @@
 # frozen_string_literal: true
 
 RSpec.describe Hubspot::Batch do
-  let(:resource1) { instance_double('Resource', changes: { name: 'John' }, resource_name: 'contacts') }
-  let(:resource2) { instance_double('Resource', changes: { name: 'Jane' }, resource_name: 'contacts') }
-  let(:invalid_resource) { instance_double('InvalidResource', resource_name: 'invalid_resource') }
-  let(:contact) do
-    instance_double('Contact', changes: { name: 'John' }, resource_name: 'contacts', email: 'john@example.com')
-  end
-
+  include_examples 'hubspot configuration'
   let(:company) do
     instance_double('Company', changes: { name: 'Acme Corp' }, resource_name: 'companies', internal_id: 123)
   end
 
-  context 'with valid resources' do
-    let(:batch) { Hubspot::Batch.new([resource1, resource2]) }
+  describe 'validity' do
+    let(:resource1) { instance_double('Resource', changes: { name: 'John' }, resource_name: 'contacts') }
+    let(:resource2) { instance_double('Resource', changes: { name: 'Jane' }, resource_name: 'contacts') }
+    let(:invalid_resource) { instance_double('InvalidResource', resource_name: 'invalid_resource') }
+    context 'with valid resources' do
+      let(:batch) { Hubspot::Batch.new([resource1, resource2]) }
 
-    it 'initializes successfully' do
-      expect(batch).to be_a(Hubspot::Batch)
+      it 'initializes successfully' do
+        expect(batch).to be_a(Hubspot::Batch)
+      end
+    end
+
+    context 'with mixed resource types' do
+      it 'raises a Hubspot::ArgumentError' do
+        expect { Hubspot::Batch.new([resource1, invalid_resource]) }.to raise_error(Hubspot::ArgumentError, /same type/)
+      end
     end
   end
 
-  context 'with mixed resource types' do
-    it 'raises a Hubspot::ArgumentError' do
-      expect { Hubspot::Batch.new([resource1, invalid_resource]) }.to raise_error(Hubspot::ArgumentError, /same type/)
+  describe '#create' do
+    let(:contact1) { Hubspot::Contact.new(email: 'john@example.com', firstname: 'John', lastname: 'Doe') }
+    let(:contact2) { Hubspot::Contact.new(email: 'jane@example.com', firstname: 'Jane', lastname: 'Doe') }
+    let(:batch) { described_class.new([contact1, contact2], id_property: 'email') }
+
+    let(:response_data) do
+      {
+        'results' => [
+          { 'id' => '1', 'properties' => { 'email' => 'john@example.com', 'firstname' => 'John', 'lastname' => 'Doe' },
+            'updatedAt' => Time.now.utc.iso8601(3) },
+          { 'id' => '2', 'properties' => { 'email' => 'jane@example.com', 'firstname' => 'Jane', 'lastname' => 'Doe' },
+            'updatedAt' => Time.now.utc.iso8601(3) }
+        ]
+      }
+    end
+
+    before do
+      # Mock the API response to return newly created contact IDs and updated properties
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: response_data, success?: true)
+      allow(Hubspot::Batch).to receive(:post).and_return(response)
+    end
+
+    it 'creates new contacts and updates their ids and properties' do
+      batch.create
+
+      # Expect the post method to have been called with the correct create URL
+      expect(batch.class).to have_received(:post).with('/crm/v3/objects/contacts/batch/create', any_args)
+
+      # Check that the IDs are updated
+      expect(contact1.id).to eq 1
+      expect(contact2.id).to eq 2
+
+      # Ensure changes are cleared after creation
+      expect(contact1.changes?).to be false
+      expect(contact2.changes?).to be false
+
+      # Ensure properties are updated, including email
+      expect(contact1.properties['email']).to eq 'john@example.com'
+      expect(contact1.properties['firstname']).to eq 'John'
+      expect(contact1.properties['lastname']).to eq 'Doe'
+
+      expect(contact2.properties['email']).to eq 'jane@example.com'
+      expect(contact2.properties['firstname']).to eq 'Jane'
+      expect(contact2.properties['lastname']).to eq 'Doe'
     end
   end
 
-  describe '#save' do
+  describe '#update' do
+    let(:contact) do
+      instance_double('Contact', changes: { name: 'John' }, resource_name: 'contacts', email: 'john@example.com')
+    end
+
+    let(:response_data) { {} }
+
     before do
       # Mock HTTParty::Response to behave like a real response object
-      response = instance_double(HTTParty::Response, code: 200, parsed_response: {}, success?: true)
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: response_data, success?: true)
 
       # Mock the post method in ApiClient to return the HTTParty::Response object
-      allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(response)
+      allow(Hubspot::Batch).to receive(:post).and_return(response)
+    end
+
+    describe 'when updating contacts' do
+      let(:contact1) { Hubspot::Contact.new(id: 1, properties: { 'name' => 'John' }) }
+      let(:contact2) { Hubspot::Contact.new(id: 2, properties: { 'name' => 'Jane' }) }
+      let(:batch) { described_class.new([contact1, contact2], id_property: 'id') }
+
+      let(:updated_at) { Time.now.utc.iso8601(3) }
+      let(:response_data) do
+        {
+          'results' => [
+            { 'id' => '1', 'properties' => { 'name' => 'John Updated' }, 'updatedAt' => updated_at },
+            { 'id' => '2', 'properties' => { 'name' => 'Jane Updated' }, 'updatedAt' => updated_at }
+          ]
+        }
+      end
+      before do
+        # Explicitly set the changes on the contacts...
+        contact1.changes = { 'name' => 'John Updated' }
+        contact2.changes = { 'name' => 'Jane Updated' }
+      end
+
+      it 'clears changes for all contacts after update' do
+        batch.update
+
+        expect(contact1.changes?).to be false
+        expect(contact2.changes?).to be false
+        expect(contact1.properties['name']).to eq 'John Updated'
+        expect(contact2.properties['name']).to eq 'Jane Updated'
+      end
     end
 
     context 'when resources are empty' do
       let(:batch) { Hubspot::Batch.new([]) }
 
       it 'raises an error' do
-        expect { batch.save }.to raise_error(RuntimeError, 'Batch is empty')
+        expect { batch.update }.to raise_error(RuntimeError, 'Batch is empty')
       end
     end
 
@@ -47,10 +129,10 @@ RSpec.describe Hubspot::Batch do
       contacts = Array.new(5) { contact } # 5 contacts
       batch = Hubspot::Batch.new(contacts, id_property: 'email')
 
-      batch.save # This should trigger the update endpoint
+      batch.update # This should trigger the update endpoint
 
       # Expect the post method to have been called with the correct update URL
-      expect(batch).to have_received(:post).with('/crm/v3/objects/contacts/batch/update', any_args)
+      expect(batch.class).to have_received(:post).with('/crm/v3/objects/contacts/batch/update', any_args)
     end
 
     context 'when batch size exceeds contact limit (10)' do
@@ -58,8 +140,8 @@ RSpec.describe Hubspot::Batch do
         contacts = Array.new(15) { contact } # 15 contacts
         batch = Hubspot::Batch.new(contacts, id_property: 'email')
 
-        # Call save and expect post to be called twice (15 / 10 = 2 API calls)
-        batch.save
+        # Call update and expect post to be called twice (15 / 10 = 2 API calls)
+        batch.update
         expect(batch.responses.size).to eq(2)
       end
     end
@@ -70,8 +152,8 @@ RSpec.describe Hubspot::Batch do
 
         batch = Hubspot::Batch.new(companies, id_property: 'internal_id')
 
-        # Call save and expect post to be called twice (150 / 100 = 2 API calls)
-        batch.save
+        # Call update and expect post to be called twice (150 / 100 = 2 API calls)
+        batch.update
         expect(batch.responses.size).to eq(2)
       end
     end
@@ -79,14 +161,14 @@ RSpec.describe Hubspot::Batch do
     context 'when some resources fail' do
       before do
         partial_success_response = instance_double(HTTParty::Response, code: 207, parsed_response: {}, success?: true)
-        allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(partial_success_response)
+        allow(Hubspot::Batch).to receive(:post).and_return(partial_success_response)
       end
 
       it 'returns a partial success' do
         companies = Array.new(5) { company }
         batch = Hubspot::Batch.new(companies, id_property: 'internal_id')
 
-        expect(batch.save).to be true
+        expect(batch.update).to be true
         expect(batch.partial_success?).to be true
         expect(batch.all_successful?).to be false
       end
@@ -101,7 +183,7 @@ RSpec.describe Hubspot::Batch do
       response = instance_double(HTTParty::Response, code: 200, parsed_response: {}, success?: true)
 
       # Mock the post method in ApiClient to return the HTTParty::Response object
-      allow_any_instance_of(Hubspot::ApiClient).to receive(:post).and_return(response)
+      allow(Hubspot::Batch).to receive(:post).and_return(response)
     end
 
     it 'makes a call to the correct upsert URL' do
@@ -110,7 +192,7 @@ RSpec.describe Hubspot::Batch do
       batch.upsert # This should trigger the upsert endpoint
 
       # Expect the post method to have been called with the correct upsert URL
-      expect(batch).to have_received(:post).with('/crm/v3/objects/companies/batch/upsert', any_args)
+      expect(batch.class).to have_received(:post).with('/crm/v3/objects/companies/batch/upsert', any_args)
     end
 
     context "when some resources don't have a value for the id property" do
@@ -121,7 +203,50 @@ RSpec.describe Hubspot::Batch do
 
       it 'will raise an error' do
         batch = Hubspot::Batch.new(companies_including_incomplete, id_property: 'internal_id')
-        expect{ batch.upsert }.to raise_error(Hubspot::ArgumentError)
+        expect { batch.upsert }.to raise_error(Hubspot::ArgumentError)
+      end
+    end
+  end
+  
+  describe '#archive' do
+    let(:contact1) { Hubspot::Contact.new(id: 1, properties: { 'email' => 'john@example.com', 'firstname' => 'John' }) }
+    let(:contact2) { Hubspot::Contact.new(id: 2, properties: { 'email' => 'jane@example.com', 'firstname' => 'Jane' }) }
+    let(:batch) { described_class.new([contact1, contact2], id_property: 'id') }
+
+    before do
+      # Mock the API response for archive
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: {}, success?: true)
+      allow(Hubspot::Batch).to receive(:post).and_return(response)
+    end
+
+    it 'makes a call to the correct archive URL' do
+      batch.archive
+
+      # Ensure the post method was called with the correct URL
+      expect(batch.class).to have_received(:post).with('/crm/v3/objects/contacts/batch/archive', any_args)
+    end
+
+    it 'does not call process_results after archiving' do
+      # Stub process_results to track if it was called
+      allow(batch).to receive(:process_results)
+
+      batch.archive
+
+      # Ensure that process_results was not called
+      expect(batch).not_to have_received(:process_results)
+    end
+
+    context 'when some resources fail to archive' do
+      before do
+        # Simulate a partial success response
+        partial_success_response = instance_double(HTTParty::Response, code: 207, parsed_response: {}, success?: true)
+        allow(Hubspot::Batch).to receive(:post).and_return(partial_success_response)
+      end
+
+      it 'returns partial success' do
+        batch.archive
+        expect(batch.partial_success?).to be true
+        expect(batch.all_successful?).to be false
       end
     end
   end

--- a/spec/hubspot/config_spec.rb
+++ b/spec/hubspot/config_spec.rb
@@ -34,6 +34,55 @@ RSpec.describe Hubspot do
       expect(Hubspot.config.client_secret).to eq('test_client_secret')
     end
 
+    it 'sets and retrieves the default request timeout via the Hubspot module' do
+      Hubspot.configure do |config|
+        config.timeout = 10
+      end
+
+      expect(Hubspot.config.timeout).to eq(10)
+      expect(Hubspot::ApiClient.default_options[:timeout]).to eq(10)
+    end
+
+    it 'sets and retrieves the open_timeout via the Hubspot module' do
+      Hubspot.configure do |config|
+        config.open_timeout = 10
+      end
+
+      expect(Hubspot.config.open_timeout).to eq(10)
+      expect(Hubspot::ApiClient.default_options[:open_timeout]).to eq(10)
+    end
+
+    it 'sets and retrieves the read_timeout via the Hubspot module' do
+      Hubspot.configure do |config|
+        config.read_timeout = 10
+      end
+
+      expect(Hubspot.config.read_timeout).to eq(10)
+      expect(Hubspot::ApiClient.default_options[:read_timeout]).to eq(10)
+    end
+
+    context 'when RUBY_VERSION >= 2.6' do
+      it 'sets and retrieves the write_timeout via the Hubspot module', if: RUBY_VERSION >= '2.6' do
+        Hubspot.configure do |config|
+          config.write_timeout = 10
+        end
+
+        expect(Hubspot.config.write_timeout).to eq(10)
+        expect(Hubspot::ApiClient.default_options[:write_timeout]).to eq(10)
+      end
+    end
+
+    context 'when RUBY_VERSION < 2.6' do
+      it 'will not write_timeout via the Hubspot module when provided', if: RUBY_VERSION < '2.6' do
+        Hubspot.configure do |config|
+          config.write_timeout = 10
+        end
+
+        expect(Hubspot.config.write_timeout).to eq(10)
+        expect(Hubspot::ApiClient.default_options[:write_timeout]).to be_nil
+      end
+    end
+
     describe 'with the HUBSPOT_LOG_LEVEL env var' do
       before(:each) { @original_level = ENV['HUBSPOT_LOG_LEVEL'] }
       after(:each) { ENV['HUBSPOT_LOG_LEVEL'] = @original_level }

--- a/spec/hubspot/contact_spec.rb
+++ b/spec/hubspot/contact_spec.rb
@@ -271,4 +271,16 @@ RSpec.describe Hubspot::Contact do
       end
     end
   end
+
+  describe 'when intialised with email property' do
+    let(:contact) { Hubspot::Contact.new(email: 'leya@rebelaliance.org') }
+
+    it 'will respond to .email' do
+      expect(contact).to respond_to(:email)
+    end
+
+    it 'will not respond_to .firstname' do
+      expect { contact.firstname }.to raise_error(NoMethodError)
+    end
+  end
 end

--- a/spec/hubspot/paged_batch_spec.rb
+++ b/spec/hubspot/paged_batch_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Hubspot::PagedBatch do
+  include_examples 'hubspot configuration'
+
+  let(:contacts_batch_read_page) { 'https://api.hubapi.com/crm/v3/objects/contacts/batch/read' }
+  let(:contact_ids) { (1...15).to_a }
+
+  let(:contacts) { Hubspot::Contact.batch_read(contact_ids) }
+  context 'when hitting the rate limit' do
+    before do
+      # Stub the request to return a 429 rate-limit response (with immediate retry ;)
+      stub_request(:post, contacts_batch_read_page)
+        .to_return(status: 429, body: 'Rate limit exceeded', headers: { 'Retry-After' => '0' })
+
+      # Redefine the MAX_RETRIES constant to 2 for this test
+      stub_const('Hubspot::ApiClient::MAX_RETRIES', 2)
+    end
+
+    it 'makes the correct number of retry attempts when receiving a 429 rate limit response' do
+      expect { contacts.each_page { |page| page } }.to raise_error(Hubspot::RateLimitExceededError)
+      expect(WebMock).to have_requested(:post, contacts_batch_read_page).times(3)
+    end
+  end
+
+  context 'when fetching all 15 contacts' do
+    def new_contact(seq)
+      { 'id' => seq + 1, 'properties' => { 'firstname' => "Contact #{seq + 1}" } }
+    end
+
+    before do
+      stub_const('Hubspot::PagedBatch::MAX_LIMIT', 10)
+      # Stub the first page of contacts (10 contacts) with a 'next' paging parameter
+      stub_request(:post, contacts_batch_read_page)
+        .with(body: /"id":10/)
+        .to_return(
+          status: 200,
+          body: {
+            'results' => Array.new(10) { |i| new_contact(i) }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      # Stub the second page of contacts (5 contacts) with no 'next' page
+      stub_request(:post, contacts_batch_read_page)
+        .with(body: /"id":11/)
+        .to_return(
+          status: 200,
+          body: {
+            'results' => Array.new(5) { |i| new_contact(i + 10) }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+    end
+
+    let(:all_contacts) { contacts.all }
+
+    it 'fetches all contacts in two pages and makes two requests' do
+      # Ensure the correct number of contacts are retrieved
+      expect(all_contacts.size).to eq(15)
+
+      # Check the contacts for correctness
+      expect(all_contacts.map { |contact| contact.properties['firstname'] }).to include('Contact 1', 'Contact 15')
+
+      # Verify that both page requests were made
+      expect(a_request(:post, contacts_batch_read_page)).to have_been_made.twice
+    end
+
+    it 'can be iterated over and it will fetch 2 pages' do
+      # Ensure the correct number of contacts are retrieved
+      contacts.each do |contact|
+        expect(contact).to be_a(Hubspot::Contact)
+      end
+
+      # Verify that both page requests were made
+      expect(a_request(:post, contacts_batch_read_page)).to have_been_made.twice
+      expect(WebMock).to have_requested(:post, contacts_batch_read_page).with(body: Regexp.new({ id: 10 }.to_json)).once
+    end
+  end
+end

--- a/spec/hubspot/paged_collection_spec.rb
+++ b/spec/hubspot/paged_collection_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Hubspot::PagedCollection do
+  include_examples 'hubspot configuration'
+
   let(:contacts_list_page) { 'https://api.hubapi.com/crm/v3/objects/contacts' }
   let(:contacts) { Hubspot::Contact.list }
 
@@ -11,7 +13,7 @@ RSpec.describe Hubspot::PagedCollection do
         .to_return(status: 429, body: 'Rate limit exceeded', headers: { 'Retry-After' => '0' })
 
       # Redefine the MAX_RETRIES constant to 2 for this test
-      stub_const('Hubspot::PagedCollection::MAX_RETRIES', 2)
+      stub_const('Hubspot::ApiClient::MAX_RETRIES', 2)
     end
 
     it 'makes the correct number of retry attempts when receiving a 429 rate limit response' do


### PR DESCRIPTION
Adds batch operations read, create, update, upsert and archive

New class introduced `Hubspot::Batch` which can be use to retrieve (read) or create, update, upsert, archive a collection of objects using Hubspot's batch api 

Closes #1 